### PR TITLE
fix: focus the LLM window if a user toggles it

### DIFF
--- a/lua/sllm/ui.lua
+++ b/lua/sllm/ui.lua
@@ -186,7 +186,8 @@ function M.toggle_llm_buffer(window_type, model_name)
   if win then
     vim.api.nvim_win_close(win, false)
   else
-    M.show_llm_buffer(window_type, model_name)
+    win = M.show_llm_buffer(window_type, model_name)
+    vim.api.nvim_set_current_win(win)
   end
 end
 


### PR DESCRIPTION
Small quality of life improvement: if a user issues the "toggle_llm_buffer" command, they almost always also want to focus it.