### PR TITLE
llm backend config implemented

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -152,14 +152,6 @@ Open picker to select a template.
 require('sllm').select_template()
 ```
 
-### Sllm.show_template()
-
-Display the active template's contents in the LLM buffer.
-
-```lua
-require('sllm').show_template()
-```
-
 ### Sllm.edit_template()
 
 Open the active template file for editing in Neovim.

--- a/doc/slash_commands.md
+++ b/doc/slash_commands.md
@@ -80,11 +80,8 @@ passed to the model with `-o key value`.
 
 ## Template commands
 
-**`/template-show`** - Show the active template's contents. Displays the YAML
-configuration in the LLM buffer.
-
 **`/template-edit`** - Open the active template file for editing. Opens the YAML
-file in a new buffer so you can customize it.
+file in a new buffer with syntax highlighting.
 
 ## Copy commands
 

--- a/doc/sllm.txt
+++ b/doc/sllm.txt
@@ -382,11 +382,8 @@ passed to the model with `-o key value`.
 
 Template commands
 
-`/template-show` - Show the active template's contents. Displays the YAML
-configuration in the LLM buffer.
-
 `/template-edit` - Open the active template file for editing. Opens the YAML
-file in a new buffer so you can customize it.
+file in a new buffer with syntax highlighting.
 
 Copy commands
 
@@ -1330,13 +1327,6 @@ Open picker to select a template.
 
 >lua
     require('sllm').select_template()
-<
-Sllm.show_template()
-
-Display the active template's contents in the LLM buffer.
-
->lua
-    require('sllm').show_template()
 <
 Sllm.edit_template()
 

--- a/lua/sllm/backend/llm.lua
+++ b/lua/sllm/backend/llm.lua
@@ -6,6 +6,11 @@
 local Backend = { name = 'llm' }
 local H = {}
 
+-- Private state ==============================================================
+H.state = {
+  job_id = nil, -- current job ID
+}
+
 -- Helper data ================================================================
 
 -- Treat these extensions as attachments (images, documents, archives, media, etc.).
@@ -84,156 +89,83 @@ H.is_attachment = function(filename)
   return H.ATTACHMENT_EXTENSIONS[ext] == true
 end
 
--- Public API =================================================================
+-- Remove ANSI escape codes from a string.
+H.strip_ansi_codes = function(text)
+  local ansi_escape_pattern = '[\27\155][][()#;?%][0-9;]*[A-Za-z@^_`{|}~]'
+  return text:gsub(ansi_escape_pattern, '')
+end
 
----@class BackendSetupOptions
----@field plugin_templates_path string? Path to plugin templates directory.
----@field on_template_installed fun(filename: string)? Callback when a template is installed.
----@field on_ready fun(default_model: string?)? Callback when setup is complete, receives default model.
+-- Start a new job and stream its output line by line.
+-- Wraps the command in bash to prefix stdout lines with `--stdout ` and
+-- stderr lines with `--stderr `, then routes them to the appropriate handlers.
+H.job_start = function(cmd, on_stdout, on_stderr, on_exit)
+  -- Helper to route a line to the appropriate handler based on --stdout/--stderr prefix
+  local function route_line(line)
+    local stripped = H.strip_ansi_codes(line):gsub('\r', '')
+    local stdout_content = stripped:match('^%-%-stdout (.*)$')
+    local stderr_content = stripped:match('^%-%-stderr (.*)$')
 
----Async setup for the LLM backend. Fetches default model and installs templates.
----@param config table Backend configuration with cmd field.
----@param options BackendSetupOptions? Setup options.
-Backend.setup_async = function(config, options)
-  options = options or {}
-  local plugin_templates_path = options.plugin_templates_path
-  local on_template_installed = options.on_template_installed
-  local on_ready = options.on_ready
-  local llm_cmd = config.cmd or 'llm'
-
-  -- Track completion of async tasks
-  local default_model = nil
-  local templates_done = false
-  local model_done = false
-
-  local function check_ready()
-    if templates_done and model_done and on_ready then
-      on_ready(default_model)
+    if stdout_content then
+      on_stdout(stdout_content)
+    elseif stderr_content then
+      on_stderr(stderr_content)
+    elseif stripped == '--stdout' then
+      on_stdout('')
+    elseif stripped == '--stderr' then
+      on_stderr('')
+    else
+      on_stdout(stripped)
     end
   end
 
-  -- Fetch default model asynchronously
-  vim.system({ llm_cmd, 'models', 'default' }, { text = true }, function(result)
-    local output = result.stdout or ''
-    default_model = output:match('(.-)%s*$')
-    vim.schedule(function()
-      model_done = true
-      check_ready()
-    end)
-  end)
-
-  -- Install templates if path provided
-  if not plugin_templates_path or vim.fn.isdirectory(plugin_templates_path) == 0 then
-    templates_done = true
-    check_ready()
-    return
-  end
-
-  local template_files = vim.fn.glob(plugin_templates_path .. '/sllm_*.yaml', false, true)
-  if #template_files == 0 then
-    templates_done = true
-    check_ready()
-    return
-  end
-
-  -- Get llm templates path asynchronously
-  H.get_templates_path_async(llm_cmd, function(templates_path)
-    if not templates_path then
-      templates_done = true
-      check_ready()
-      return
+  -- Build shell command that prefixes stdout with --stdout and stderr with --stderr
+  local base_cmd
+  if type(cmd) == 'table' then
+    local escaped_parts = {}
+    for _, part in ipairs(cmd) do
+      table.insert(escaped_parts, vim.fn.shellescape(part))
     end
+    base_cmd = table.concat(escaped_parts, ' ')
+  else
+    base_cmd = cmd
+  end
+  local shell_cmd = string.format("{ { %s | sed 's/^/--stdout /'; } 2>&1 1>&3 | sed 's/^/--stderr /'; } 3>&1", base_cmd)
 
-    for _, src_file in ipairs(template_files) do
-      src_file = vim.fn.fnamemodify(src_file, ':p')
-      local filename = vim.fn.fnamemodify(src_file, ':t')
-      local dst_file = templates_path .. '/' .. filename
-
-      if vim.fn.filereadable(dst_file) == 0 then
-        vim.system({ 'ln', '-s', src_file, dst_file }, { text = true }, function(ln_result)
-          if ln_result.code == 0 and on_template_installed then
-            vim.schedule(function()
-              on_template_installed(filename)
-            end)
-          end
-        end)
-      elseif vim.fn.getftype(dst_file) == 'link' then
-        local target = vim.fn.resolve(dst_file)
-        if target ~= src_file then
-          vim.fn.delete(dst_file)
-          vim.system({ 'ln', '-s', src_file, dst_file }, { text = true })
-        end
+  H.state.job_id = vim.fn.jobstart({ 'bash', '-c', shell_cmd }, {
+    stdout_buffered = false,
+    pty = true,
+    on_stdout = function(_, data, _)
+      if not data then return end
+      for _, line in ipairs(data) do
+        if line ~= '' then route_line(line) end
       end
-    end
-
-    templates_done = true
-    check_ready()
-  end)
+    end,
+    on_stderr = function(_, data, _)
+      if not data then return end
+      for _, line in ipairs(data) do
+        if line ~= '' then on_stderr(H.strip_ansi_codes(line)) end
+      end
+    end,
+    on_exit = function(_, exit_code, _)
+      H.state.job_id = nil
+      on_exit(exit_code)
+    end,
+  })
 end
 
----Get list of available models from llm CLI.
----@param config table Backend configuration with cmd field.
----@return string[] List of model names.
-Backend.get_models = function(config)
-  local llm_cmd = config.cmd or 'llm'
-  local result = vim.system({ llm_cmd, 'models' }, { text = true }):wait()
-  local models = vim.split(result.stdout or '', '\n', { plain = true, trimempty = true })
-  local only_models = {}
-  for _, line in ipairs(models) do
-    local model = line:match('^.-:%s*([^(%s]+)')
-    if model then table.insert(only_models, model) end
+-- Stop the currently running job, if any.
+H.job_stop = function()
+  if H.state.job_id then
+    vim.fn.jobstop(H.state.job_id)
+    H.state.job_id = nil
   end
-  return only_models
 end
 
----Get model-specific options.
----@param config table Backend configuration with cmd field.
----@param model string Model name.
----@return string[] List of options description lines.
-Backend.get_model_options = function(config, model)
-  local llm_cmd = config.cmd or 'llm'
-  local result = vim.system({ llm_cmd, 'models', '--options', '-m', model }, { text = true }):wait()
-  return vim.split(result.stdout or '', '\n', { plain = true, trimempty = true })
-end
-
----Get list of available tools from llm CLI.
----@param config table Backend configuration with cmd field.
----@return string[] List of tool names.
-Backend.get_tools = function(config)
-  local llm_cmd = config.cmd or 'llm'
-  local result = vim.system({ llm_cmd, 'tools', 'list', '--json' }, { text = true }):wait()
-  local json_string = result.stdout or ''
-  local spec = H.parse_json(json_string)
-  local names = {}
-  if spec and spec.tools then
-    for _, tool in ipairs(spec.tools) do
-      table.insert(names, tool.name)
-    end
-  end
-  return names
-end
-
----@class LlmBuildCommandOptions
----@field prompt string Required prompt text.
----@field model string? Model name.
----@field template string? Template name.
----@field continue boolean|string? Continue conversation (true for -c, string for --cid).
----@field show_usage boolean? Show token usage.
----@field no_stream boolean? Disable streaming output.
----@field raw boolean? Skip tool flags (--td --cl) for simple prompts.
----@field ctx_files string[]? Context files to include.
----@field tools string[]? Tool names to use.
----@field functions string[]? Python functions to use.
----@field online boolean? Enable online mode.
----@field system_prompt string? System prompt.
----@field model_options table? Model-specific options.
----@field chain_limit integer? Chain limit for tools (default: 100).
-
----Build the llm CLI command string or table.
+-- Build the llm CLI command (private helper).
 ---@param config table Backend configuration with cmd field.
 ---@param options LlmBuildCommandOptions Command options.
 ---@return string[] The assembled shell command.
-Backend.build_command = function(config, options)
+H.build_command = function(config, options)
   local llm_cmd = config.cmd or 'llm'
   local cmd = { llm_cmd }
 
@@ -313,7 +245,289 @@ Backend.build_command = function(config, options)
   return cmd
 end
 
----Fetch history entries from llm logs.
+-- Public API =================================================================
+
+---@class BackendSetupOptions
+---@field plugin_templates_path string? Path to plugin templates directory.
+---@field on_template_installed fun(filename: string)? Callback when a template is installed.
+---@field on_ready fun(default_model: string?)? Callback when setup is complete, receives default model.
+
+---Async setup for the LLM backend. Fetches default model and installs templates.
+---@param config table Backend configuration with cmd field.
+---@param options BackendSetupOptions? Setup options.
+Backend.setup_async = function(config, options)
+  options = options or {}
+  local plugin_templates_path = options.plugin_templates_path
+  local on_template_installed = options.on_template_installed
+  local on_ready = options.on_ready
+  local llm_cmd = config.cmd or 'llm'
+
+  -- Track completion of async tasks
+  local default_model = nil
+  local templates_done = false
+  local model_done = false
+
+  local function check_ready()
+    if templates_done and model_done and on_ready then on_ready(default_model) end
+  end
+
+  -- Fetch default model asynchronously
+  vim.system({ llm_cmd, 'models', 'default' }, { text = true }, function(result)
+    local output = result.stdout or ''
+    default_model = output:match('(.-)%s*$')
+    vim.schedule(function()
+      model_done = true
+      check_ready()
+    end)
+  end)
+
+  -- Install templates if path provided
+  if not plugin_templates_path or vim.fn.isdirectory(plugin_templates_path) == 0 then
+    templates_done = true
+    check_ready()
+    return
+  end
+
+  local template_files = vim.fn.glob(plugin_templates_path .. '/sllm_*.yaml', false, true)
+  if #template_files == 0 then
+    templates_done = true
+    check_ready()
+    return
+  end
+
+  -- Get llm templates path asynchronously
+  H.get_templates_path_async(llm_cmd, function(templates_path)
+    if not templates_path then
+      templates_done = true
+      check_ready()
+      return
+    end
+
+    for _, src_file in ipairs(template_files) do
+      src_file = vim.fn.fnamemodify(src_file, ':p')
+      local filename = vim.fn.fnamemodify(src_file, ':t')
+      local dst_file = templates_path .. '/' .. filename
+
+      if vim.fn.filereadable(dst_file) == 0 then
+        vim.system({ 'ln', '-s', src_file, dst_file }, { text = true }, function(ln_result)
+          if ln_result.code == 0 and on_template_installed then
+            vim.schedule(function() on_template_installed(filename) end)
+          end
+        end)
+      elseif vim.fn.getftype(dst_file) == 'link' then
+        local target = vim.fn.resolve(dst_file)
+        if target ~= src_file then
+          vim.fn.delete(dst_file)
+          vim.system({ 'ln', '-s', src_file, dst_file }, { text = true })
+        end
+      end
+    end
+
+    templates_done = true
+    check_ready()
+  end)
+end
+
+---Cancel the current running job.
+---@return nil
+Backend.cancel = function() H.job_stop() end
+
+---Check if a job is currently running.
+---@return boolean True if a job is active.
+Backend.is_busy = function() return H.state.job_id ~= nil end
+
+---@class PromptUsage
+---@field input integer Input tokens used.
+---@field output integer Output tokens generated.
+---@field cost number Cost in dollars.
+
+---@class PromptCallbacks
+---@field on_line fun(line: string)? Callback for each output line (response + tool calls).
+---@field on_exit fun(exit_code: integer, conversation_id: string?, usage: PromptUsage?)? Callback when job exits.
+
+---Prompt the LLM asynchronously.
+---Handles token usage tracking internally and formats tool call headers.
+---@param config table Backend configuration with cmd field.
+---@param options LlmBuildCommandOptions Prompt options.
+---@param callbacks PromptCallbacks Callbacks for line output and exit.
+---@return nil
+Backend.prompt_async = function(config, options, callbacks)
+  callbacks = callbacks or {}
+  local on_line = callbacks.on_line or function() end
+  local on_exit = callbacks.on_exit or function() end
+
+  -- Accumulated usage stats
+  local usage = { input = 0, output = 0, cost = 0 }
+
+  local cmd = H.build_command(config, options)
+
+  H.job_start(
+    cmd,
+    -- stdout handler: pass through to on_line
+    on_line,
+    -- stderr handler: parse usage, format tool calls, filter tool output
+    function(line)
+      -- Parse token usage and accumulate stats
+      local parsed_usage = Backend.parse_token_usage(line)
+      if parsed_usage then
+        usage.input = usage.input + parsed_usage.input
+        usage.output = usage.output + parsed_usage.output
+        usage.cost = usage.cost + parsed_usage.cost
+        return
+      end
+
+      -- Format tool call headers as markdown
+      if Backend.is_tool_call_header(line) then
+        local tool_call = line:match('^Tool call:%s*(.+)$')
+        if tool_call then
+          if #tool_call > 60 then tool_call = tool_call:sub(1, 57) .. '...' end
+          on_line('🔧 Tool: `' .. tool_call .. '`')
+        else
+          on_line(line)
+        end
+        return
+      end
+
+      -- Filter out tool call outputs (indented lines following Tool call headers)
+      if Backend.is_tool_call_output(line) then return end
+
+      -- Pass through other non-empty stderr lines
+      if line ~= '' then on_line(line) end
+    end,
+    -- exit handler: fetch conversation ID and pass usage
+    function(exit_code)
+      local conversation_id = nil
+      if exit_code == 0 then
+        local llm_cmd = config.cmd or 'llm'
+        local result = vim.system({ llm_cmd, 'logs', 'list', '--json', '-n', '1' }, { text = true }):wait()
+        local output = result.stdout or ''
+        local parsed = H.parse_json(output)
+        if parsed and #parsed > 0 then conversation_id = parsed[1].conversation_id end
+      end
+      -- Only pass usage if we collected any
+      local final_usage = (usage.input > 0 or usage.output > 0) and usage or nil
+      on_exit(exit_code, conversation_id, final_usage)
+    end
+  )
+end
+
+---Get the built command for debugging purposes.
+---@param config table Backend configuration with cmd field.
+---@param options LlmBuildCommandOptions Command options.
+---@return string[] The assembled shell command.
+Backend.get_command = function(config, options) return H.build_command(config, options) end
+
+---@class LlmBuildCommandOptions
+---@field prompt string Required prompt text.
+---@field model string? Model name.
+---@field template string? Template name.
+---@field continue boolean|string? Continue conversation (true for -c, string for --cid).
+---@field show_usage boolean? Show token usage.
+---@field no_stream boolean? Disable streaming output.
+---@field raw boolean? Skip tool flags (--td --cl) for simple prompts.
+---@field ctx_files string[]? Context files to include.
+---@field tools string[]? Tool names to use.
+---@field functions string[]? Python functions to use.
+---@field online boolean? Enable online mode.
+---@field system_prompt string? System prompt.
+---@field model_options table? Model-specific options.
+---@field chain_limit integer? Chain limit for tools (default: 100).
+
+---Get list of available models from llm CLI (sync).
+---@param config table Backend configuration with cmd field.
+---@return string[] List of model names.
+Backend.get_models = function(config)
+  local llm_cmd = config.cmd or 'llm'
+  local result = vim.system({ llm_cmd, 'models' }, { text = true }):wait()
+  local models = vim.split(result.stdout or '', '\n', { plain = true, trimempty = true })
+  local only_models = {}
+  for _, line in ipairs(models) do
+    local model = line:match('^.-:%s*([^(%s]+)')
+    if model then table.insert(only_models, model) end
+  end
+  return only_models
+end
+
+---Get list of available models from llm CLI (async).
+---@param config table Backend configuration with cmd field.
+---@param callback fun(models: string[]) Callback with list of model names.
+---@return nil
+Backend.get_models_async = function(config, callback)
+  local llm_cmd = config.cmd or 'llm'
+  vim.system({ llm_cmd, 'models' }, { text = true }, function(result)
+    vim.schedule(function()
+      local models = vim.split(result.stdout or '', '\n', { plain = true, trimempty = true })
+      local only_models = {}
+      for _, line in ipairs(models) do
+        local model = line:match('^.-:%s*([^(%s]+)')
+        if model then table.insert(only_models, model) end
+      end
+      callback(only_models)
+    end)
+  end)
+end
+
+---Get model-specific options (sync).
+---@param config table Backend configuration with cmd field.
+---@param model string Model name.
+---@return string[] List of options description lines.
+Backend.get_model_options = function(config, model)
+  local llm_cmd = config.cmd or 'llm'
+  local result = vim.system({ llm_cmd, 'models', '--options', '-m', model }, { text = true }):wait()
+  return vim.split(result.stdout or '', '\n', { plain = true, trimempty = true })
+end
+
+---Get model-specific options (async).
+---@param config table Backend configuration with cmd field.
+---@param model string Model name.
+---@param callback fun(options: string[]) Callback with list of options description lines.
+---@return nil
+Backend.get_model_options_async = function(config, model, callback)
+  local llm_cmd = config.cmd or 'llm'
+  vim.system({ llm_cmd, 'models', '--options', '-m', model }, { text = true }, function(result)
+    vim.schedule(function() callback(vim.split(result.stdout or '', '\n', { plain = true, trimempty = true })) end)
+  end)
+end
+
+---Get list of available tools from llm CLI (sync).
+---@param config table Backend configuration with cmd field.
+---@return string[] List of tool names.
+Backend.get_tools = function(config)
+  local llm_cmd = config.cmd or 'llm'
+  local result = vim.system({ llm_cmd, 'tools', 'list', '--json' }, { text = true }):wait()
+  local json_string = result.stdout or ''
+  local spec = H.parse_json(json_string)
+  local names = {}
+  if spec and spec.tools then
+    for _, tool in ipairs(spec.tools) do
+      table.insert(names, tool.name)
+    end
+  end
+  return names
+end
+
+---Get list of available tools from llm CLI (async).
+---@param config table Backend configuration with cmd field.
+---@param callback fun(tools: string[]) Callback with list of tool names.
+---@return nil
+Backend.get_tools_async = function(config, callback)
+  local llm_cmd = config.cmd or 'llm'
+  vim.system({ llm_cmd, 'tools', 'list', '--json' }, { text = true }, function(result)
+    vim.schedule(function()
+      local json_string = result.stdout or ''
+      local spec = H.parse_json(json_string)
+      local names = {}
+      if spec and spec.tools then
+        for _, tool in ipairs(spec.tools) do
+          table.insert(names, tool.name)
+        end
+      end
+      callback(names)
+    end)
+  end)
+end
+
+---Fetch history entries from llm logs (sync).
 ---@param config table Backend configuration with cmd field.
 ---@param options table? History options.
 ---@return table[]? List of history entries or nil.
@@ -358,6 +572,58 @@ Backend.get_history = function(config, options)
   return entries
 end
 
+---Fetch history entries from llm logs (async).
+---@param config table Backend configuration with cmd field.
+---@param options table? History options.
+---@param callback fun(entries: table[]?) Callback with list of history entries or nil.
+---@return nil
+Backend.get_history_async = function(config, options, callback)
+  options = options or {}
+  local llm_cmd = config.cmd or 'llm'
+  local count = options.count or 20
+  local cmd = { llm_cmd, 'logs', 'list', '--json', '-n', tostring(count) }
+
+  if options.query then
+    table.insert(cmd, '-q')
+    table.insert(cmd, options.query)
+  end
+  if options.model then
+    table.insert(cmd, '-m')
+    table.insert(cmd, options.model)
+  end
+
+  vim.system(cmd, { text = true }, function(result)
+    vim.schedule(function()
+      local output = result.stdout or ''
+      local parsed = H.parse_json(output)
+
+      if not parsed then
+        callback(nil)
+        return
+      end
+
+      local entries = {}
+      for _, entry in ipairs(parsed) do
+        local usage = nil
+        if entry.response_json and type(entry.response_json) == 'table' then usage = entry.response_json.usage end
+
+        table.insert(entries, {
+          id = entry.id or '',
+          conversation_id = entry.conversation_id or '',
+          model = entry.model or '',
+          prompt = entry.prompt or '',
+          response = entry.response or '',
+          system = entry.system,
+          timestamp = entry.datetime_utc or '',
+          usage = usage,
+        })
+      end
+
+      callback(entries)
+    end)
+  end)
+end
+
 ---Fetch the last conversation ID.
 ---@param config table Backend configuration with cmd field.
 ---@return string? conversation_id or nil.
@@ -371,7 +637,7 @@ Backend.get_last_conversation_id = function(config)
   return parsed[1].conversation_id
 end
 
----Get list of available templates from llm CLI.
+---Get list of available templates from llm CLI (sync).
 ---@param config table Backend configuration with cmd field.
 ---@return string[] List of template names.
 Backend.get_templates = function(config)
@@ -390,7 +656,28 @@ Backend.get_templates = function(config)
   return templates
 end
 
----Get detailed information about a template.
+---Get list of available templates from llm CLI (async).
+---@param config table Backend configuration with cmd field.
+---@param callback fun(templates: string[]) Callback with list of template names.
+---@return nil
+Backend.get_templates_async = function(config, callback)
+  local llm_cmd = config.cmd or 'llm'
+  vim.system({ llm_cmd, 'templates', 'list' }, { text = true }, function(result)
+    vim.schedule(function()
+      local output = vim.split(result.stdout or '', '\n', { plain = true, trimempty = true })
+      local templates = {}
+      for _, line in ipairs(output) do
+        if line:match('^%S+%s*:') then
+          local name = line:match('^(%S+)%s*:')
+          if name then table.insert(templates, name) end
+        end
+      end
+      callback(templates)
+    end)
+  end)
+end
+
+---Get detailed information about a template (sync).
 ---@param config table Backend configuration with cmd field.
 ---@param template_name string Name of the template.
 ---@return table? Template data (yaml content) or nil.
@@ -405,6 +692,28 @@ Backend.get_template = function(config, template_name)
     name = template_name,
     content = output,
   }
+end
+
+---Get detailed information about a template (async).
+---@param config table Backend configuration with cmd field.
+---@param template_name string Name of the template.
+---@param callback fun(template: table?) Callback with template data or nil.
+---@return nil
+Backend.get_template_async = function(config, template_name, callback)
+  local llm_cmd = config.cmd or 'llm'
+  vim.system({ llm_cmd, 'templates', 'show', template_name }, { text = true }, function(result)
+    vim.schedule(function()
+      local output = result.stdout or ''
+      if output == '' then
+        callback(nil)
+        return
+      end
+      callback({
+        name = template_name,
+        content = output,
+      })
+    end)
+  end)
 end
 
 ---Get the templates directory path.

--- a/lua/sllm/init.lua
+++ b/lua/sllm/init.lua
@@ -169,12 +169,6 @@ H.COMMANDS = {
   },
   -- Template
   {
-    cmd = 'template-show',
-    desc = 'Show template content',
-    action = 'show_template',
-    category = 'Template',
-  },
-  {
     cmd = 'template-edit',
     desc = 'Edit template file',
     action = 'edit_template',
@@ -1710,37 +1704,6 @@ end
 --- Modes are llm templates. Use `llm templates edit <name>` to customize.
 ---@return nil
 Sllm.select_mode = Sllm.select_template
-
---- Show details of the currently selected template or select one to show.
----@return nil
-function Sllm.show_template()
-  H.backend.get_templates_async(function(templates)
-    if not (templates and #templates > 0) then
-      H.notify('[sllm] no templates found.', vim.log.levels.INFO)
-      return
-    end
-
-    local template_name = H.state.selected_template
-    if not template_name or not vim.tbl_contains(templates, template_name) then
-      H.pick(templates, { prompt = 'Select template to show:', default = template_name }, function(item)
-        if item then
-          H.show_template_content(item)
-        else
-          H.notify('[sllm] no template selected', vim.log.levels.WARN)
-        end
-      end)
-    else
-      H.show_template_content(template_name)
-    end
-  end)
-end
-
--- show_template_content reuses edit_template (opens file with syntax highlighting)
-H.show_template_content = function(template_name)
-  if not H.backend.edit_template(template_name) then
-    H.notify('[sllm] template not found: ' .. template_name, vim.log.levels.ERROR)
-  end
-end
 
 --- Edit the currently selected template in your editor.
 ---@return nil

--- a/tests/test_backend.lua
+++ b/tests/test_backend.lua
@@ -25,8 +25,8 @@ T['llm']['edit_template is a function'] = function()
   MiniTest.expect.equality(type(LlmBackend.edit_template), 'function')
 end
 
-T['llm']['build_command includes template flag'] = function()
-  local cmd = LlmBackend.build_command({ cmd = 'llm' }, {
+T['llm']['get_command includes template flag'] = function()
+  local cmd = LlmBackend.get_command({ cmd = 'llm' }, {
     prompt = 'test',
     template = 'my-template',
   })

--- a/tests/test_backend.lua
+++ b/tests/test_backend.lua
@@ -28,8 +28,7 @@ T['llm']['edit_template is a function'] = function()
 end
 
 T['llm']['get_command includes template flag'] = function()
-  -- Setup backend with config (config is stored internally now)
-  LlmBackend.setup_async({ cmd = 'llm' })
+  -- H.config.cmd defaults to 'llm', so no setup needed for this test
   local cmd = LlmBackend.get_command({
     prompt = 'test',
     template = 'my-template',

--- a/tests/test_backend.lua
+++ b/tests/test_backend.lua
@@ -11,11 +11,13 @@ T['llm'] = MiniTest.new_set()
 
 T['llm']['has correct name'] = function() MiniTest.expect.equality(LlmBackend.name, 'llm') end
 
-T['llm']['get_templates is a function'] = function()
-  MiniTest.expect.equality(type(LlmBackend.get_templates), 'function')
+T['llm']['get_templates_async is a function'] = function()
+  MiniTest.expect.equality(type(LlmBackend.get_templates_async), 'function')
 end
 
-T['llm']['get_template is a function'] = function() MiniTest.expect.equality(type(LlmBackend.get_template), 'function') end
+T['llm']['get_template_async is a function'] = function()
+  MiniTest.expect.equality(type(LlmBackend.get_template_async), 'function')
+end
 
 T['llm']['get_templates_path is a function'] = function()
   MiniTest.expect.equality(type(LlmBackend.get_templates_path), 'function')

--- a/tests/test_backend.lua
+++ b/tests/test_backend.lua
@@ -28,7 +28,9 @@ T['llm']['edit_template is a function'] = function()
 end
 
 T['llm']['get_command includes template flag'] = function()
-  local cmd = LlmBackend.get_command({ cmd = 'llm' }, {
+  -- Setup backend with config (config is stored internally now)
+  LlmBackend.setup_async({ cmd = 'llm' })
+  local cmd = LlmBackend.get_command({
     prompt = 'test',
     template = 'my-template',
   })


### PR DESCRIPTION
This patch significantly refactors the `llm` backend and the core `sllm` module to move away from synchronous operations toward an **asynchronous-first architecture**.

### Key Changes:

#### 1. Asynchronous Backend Refactor (`lua/sllm/backend/llm.lua`)
*   **State Management:** Introduced a private `H.state` to track active `job_id` and a `H.config` to store the CLI command.
*   **New Async API:** Replaced blocking functions with async alternatives using callbacks:
    *   `get_models_async`, `get_tools_async`, `get_history_async`, `get_templates_async`, and `get_template_async`.
*   **Unified Prompting:** Added `prompt_async`, which encapsulates job starting, line routing, error handling, token usage accumulation, and formatted tool-call display.
*   **Setup Lifecycle:** Added `setup_async` to fetch the default model and symlink plugin templates without blocking Neovim’s UI thread on startup.

#### 2. Structural Improvements in Core (`lua/sllm/init.lua`)
*   **Lazy Loading:** Implemented `lazy_pick_func` and `lazy_notify_func`. This prevents `mini.pick` or `mini.notify` from being loaded into memory until they are actually needed, improving startup time.
*   **Job & Context Logic:**
    *   Deprecated local job management in favor of the backend's `prompt_async`.
    *   Simplified context rendering logic (removed global regex-based template rendering for a more direct string assembly).
    *   Added a `debug` mode visualization that prints the exact shell command being executed.
*   **UI Resilience:**
    *   Added a timer management helper (`ui_stop_timer`) to safely handle winbar and loading indicator debouncing.
    *   Improved the history browser and template selectors to handle asynchronous data fetching seamlessly.

#### 3. UX & Functional Enhancements
*   **Clean Output:** Added `utils_strip_code_fences` to clean up LLM responses before inserting them as code completions.
*   **Speed:** Commands like `select_model` or `browse_history` no longer cause "hiccups" in the editor while waiting for the `llm` CLI to return JSON data.
*   **Robustness:** Improved handling of `vim.NIL` and empty results from the CLI logs.

### Summary
The transition to `vim.system` and `jobstart` with callbacks ensures that Neovim remains fully responsive during long-running LLM operations or when scanning large history logs. The code is now more modular, with a clear separation between CLI command assembly and async execution.